### PR TITLE
Fixes for upcoming PHP 7.4

### DIFF
--- a/lib/Horde/Util.php
+++ b/lib/Horde/Util.php
@@ -114,7 +114,7 @@ class Horde_Util
     public static function dispelMagicQuotes($var)
     {
         if (is_null(self::$_magicquotes)) {
-            self::$_magicquotes = get_magic_quotes_gpc();
+            self::$_magicquotes = function_exists('get_magic_quotes_gpc') && @get_magic_quotes_gpc();
         }
 
         if (self::$_magicquotes) {

--- a/lib/Horde/Util.php
+++ b/lib/Horde/Util.php
@@ -304,7 +304,7 @@ class Horde_Util
         /* Get the first 8 characters of a random string to use as a temporary
            directory name. */
         do {
-            $new_dir = $temp_dir . '/' . substr(base_convert(uniqid(mt_rand()), 10, 36), 0, 8);
+            $new_dir = $temp_dir . '/' . substr(base_convert(uniqid(mt_rand()), 16, 36), 0, 8);
         } while (file_exists($new_dir));
 
         $old_umask = umask(0000);


### PR DESCRIPTION
Running Horde_Data test suite with 7.4.0RC3

```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.0RC3
Configuration: /dev/shm/BUILD/php-horde-Horde-Data-2.1.4/Horde_Data-2.1.4/test/Horde/Data/phpunit.xml

E............                                                     13 / 13 (100%)

Time: 24 ms, Memory: 4.00MB

There was 1 error:

1) Horde_Data_CsvTest::testImportFile
Function get_magic_quotes_gpc() is deprecated

/usr/share/pear/Horde/Util.php:117
/usr/share/pear/Horde/Variables.php:73
/usr/share/pear/Horde/Variables.php:57
/dev/shm/BUILD/php-horde-Horde-Data-2.1.4/Horde_Data-2.1.4/lib/Horde/Data/Base.php:105
/dev/shm/BUILD/php-horde-Horde-Data-2.1.4/Horde_Data-2.1.4/test/Horde/Data/CsvTest.php:14

ERRORS!
Tests: 13, Assertions: 21, Errors: 1.

```