### PR TITLE
PHP 8 issues with convertCharset

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -157,6 +157,9 @@ class Horde_String
 
         /* Try mbstring. */
         if (Horde_Util::extensionExists('mbstring')) {
+            if (!in_array($from, mb_list_encodings()) || !in_array($to, mb_list_encodings())) {
+                return $input;
+            }
             $out = @mb_convert_encoding($input, $to, self::_mbstringCharset($from));
             if (!empty($out)) {
                 return $out;


### PR DESCRIPTION
There were changes to the `@` error suppression (https://php.watch/versions/8.0/fatal-error-suppression) in PHP 8, which is used in a number of places in this Utility repo. We're running a nextcloud instance with the Mail app, which uses the horde IMAP Client, which makes use of this Utility repo when trying to convert strings to different charsets in a CRON job.

This CRON now fails due to an unsuppressed error triggered by `@mb_convert_encoding` in `String.php`. In our case, there's some exotic unsupported charset (`unicode-1-1-utf-7`). To solve this specific case, we added a small guard condition that checks the available encodings of `mb_convert_encoding()` (with `mb_list_encodings()`) and returns the raw input, if the input or output is of an unsupported encoding.

There might be a more elegant way of handling this (and more work to be done with regards to PHP8) and I actually just wanted to create an issue, but issues are turned off for this repo, so there's that. ;-)