### PR TITLE
fix PHP 8.0 ValueError: mb_convert_encoding()

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -157,10 +157,16 @@ class Horde_String
 
         /* Try mbstring. */
         if (Horde_Util::extensionExists('mbstring')) {
-            $out = @mb_convert_encoding($input, $to, self::_mbstringCharset($from));
-            if (!empty($out)) {
-                return $out;
-            }
+			try {
+				$out = @mb_convert_encoding($input, $to, self::_mbstringCharset($from));
+				if (!empty($out))
+				{
+					return $out;
+				}
+			}
+			catch (ValueError $e) {
+				// catch error thrown under PHP 8.0, if mbstring does not support the encoding
+			}
         }
 
         return $input;


### PR DESCRIPTION
Argument #3 ($from_enoding) must specify at least one encoding

happens if you use mb_convert_encoding with an unsupported charset