### PR TITLE
Handle empty charset warning in PHP 8

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -890,6 +890,10 @@ class Horde_String
      */
     protected static function _mbstringCharset($charset)
     {
+        if ($charset === "") {
+            return null;
+        }
+
         /* mbstring functions do not handle the 'ks_c_5601-1987' &
          * 'ks_c_5601-1989' charsets. However, these charsets are used, for
          * example, by various versions of Outlook to send Korean characters.


### PR DESCRIPTION
Relates to #3, #5

Probably needs more thought but `Horde_Mime_Mdn_NonTranslatedTest::testGenerate` fails with:
```
ValueError: mb_strlen(): Argument #2 ($encoding) must be a valid encoding, "" given

/home/runner/work/Mime/Mime/vendor/bytestream/horde-util/lib/Horde/String.php:380
/home/runner/work/Mime/Mime/vendor/bytestream/horde-text-flowed/lib/Horde/Text/Flowed.php:270
/home/runner/work/Mime/Mime/vendor/bytestream/horde-text-flowed/lib/Horde/Text/Flowed.php:173
/home/runner/work/Mime/Mime/lib/Horde/Mime/Mdn.php:210
/home/runner/work/Mime/Mime/test/Horde/Mime/Mdn/NonTranslatedTest.php:71
```

This is because charset in `Mdn` defaults to `null`, is converted to lowercase which creates `''` and results in the `ValueError` exception.