### PR TITLE
Fix deprecated `$php_errormsg` in PHP 7.2

### DIFF
--- a/test/Horde/Util/Mock/String.php
+++ b/test/Horde/Util/Mock/String.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Wrapper to test internal Horde_String methods.
+ *
+ * @author    Daniel Ziegenberg <daniel@ziegenberg.at>
+ * @category  Horde
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Util
+ */
+class Horde_Util_Mock_String extends Horde_String
+{
+    public static function testConvertCharsetIconv(string $input, string $from, string $to)
+    {
+        return self::_convertCharsetIconv($input, $from, $to);
+    }
+
+    public static function testPosMbstring(string $haystack, string $needle, int $offset, string $charset, string $func)
+    {
+        return self::_posMbstring($haystack, $needle, $offset, $charset, $func);
+    }
+
+    public static function testPosIntl(string $haystack, string $needle, int $offset, string $charset, string $func)
+    {
+        return self::_posIntl($haystack, $needle, $offset, $charset, $func);
+    }
+}

--- a/test/Horde/Util/StringTest.php
+++ b/test/Horde/Util/StringTest.php
@@ -731,4 +731,61 @@ EOT
         );
     }
 
+    /**
+     * @dataProvider ConvertCharsetIconvProvider
+     */
+    public function testConvertCharsetIconv(string $input, string $from, string $to, $expected): void
+    {
+        $this->assertEquals(
+            $expected,
+            Horde_Util_Mock_String::testConvertCharsetIconv($input, $from, $to)
+        );
+    }
+
+    public function ConvertCharsetIconvProvider()
+    {
+        return [
+            'valid character sequence' => ['This will work.', 'UTF-8', 'ISO-8859-1', 'This will work.'],
+            'illegal character in input string' => ["This is the Euro symbol '€'.", 'UTF-8', 'ISO-8859-1', false]
+        ];
+    }
+
+    /**
+     * @dataProvider posMbstringProvider
+     */
+    public function testPosMbstring(string $haystack, string $needle, int $offset, string $charset, string $func, $expected): void
+    {
+        $this->assertEquals(
+            $expected,
+            Horde_Util_Mock_String::testPosMbstring($haystack, $needle, $offset, $charset, $func)
+        );
+    }
+
+    public function posMbstringProvider()
+    {
+        return [
+            'valid character sequence' => ['Some random string.', 'Some', 0, 'UTF-8', 'strpos', 0],
+            'invalid search offset' => ['Some random string', 'Some', 50, 'UTF-8', 'strpos', false]
+        ];
+    }
+
+    /**
+     * @dataProvider posIntlProvider
+     */
+    public function testPosIntl(string $haystack, string $needle, int $offset, string $charset, string $func, $expected): void
+    {
+        $this->assertEquals(
+            $expected,
+            Horde_Util_Mock_String::testPosIntl($haystack, $needle, $offset, $charset, $func)
+        );
+    }
+
+    public function posIntlProvider()
+    {
+        return [
+            'valid character sequence' => ['Some random string.', 'Some', 0, 'UTF-8', 'strpos', 0],
+            'invalid search offset' => ['Some random string', 'Some', 50, 'UTF-8', 'strpos', false]
+        ];
+    }
+
 }


### PR DESCRIPTION
From the PHP 8.0 migration guide (https://www.php.net/manual/de/migration80.incompatible.php):

> The `track_errors` ini directive has been removed.
> This means that `$php_errormsg` is no longer available.
> The `error_get_last()` function may be used instead.

Also the documentation on `$php_errormsg` (https://www.php.net/manual/en/reserved.variables.phperrormsg.php) says:

> This feature has been DEPRECATED as of PHP 7.2.0.
> Relying on this feature is highly discouraged.
> Use `error_get_last()` instead.


The functions `Horde_String::convertCharset` and `Horde_String::_pos` are broken up to assist in better testability and additional tests for the newly introduced functions are added.


This commit breaks compatibility with PHP 5.6 as `error_clear_last()` was introduced with PHP 7.