### PR TITLE
Fix strlower'ing null

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -199,7 +199,11 @@ class Horde_String
         if (!isset(self::$_lowers[$string])) {
             $language = setlocale(LC_CTYPE, 0);
             setlocale(LC_CTYPE, 'C');
-            self::$_lowers[$string] = strtolower($string);
+            if ($string === null) {
+                self::$_lowers[$string] = '';
+            } else {
+                self::$_lowers[$string] = strtolower($string);
+            }
             setlocale(LC_CTYPE, $language);
         }
 


### PR DESCRIPTION
Fixes ``PHP Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated`` with PHP8.1

Lowering null results in an empty string: https://3v4l.org/jF91B