### PR TITLE
Fixed utf8_encode and utf8_decode functions deprecated in PHP 8.2

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -115,13 +115,15 @@ class Horde_String
              !Horde_Util::extensionExists('iconv') ||
              !Horde_Util::extensionExists('mbstring'))) {
             if (($to == 'utf-8') &&
+                function_exists('utf8_encode') &&
                 in_array($from, array('iso-8859-1', 'us-ascii', 'utf-8'))) {
-                return utf8_encode($input);
+                return @utf8_encode($input);
             }
 
             if (($from == 'utf-8') &&
+                function_exists('utf8_decode') &&
                 in_array($to, array('iso-8859-1', 'us-ascii', 'utf-8'))) {
-                return utf8_decode($input);
+                return @utf8_decode($input);
             }
         }
 
@@ -381,7 +383,12 @@ class Horde_String
         $charset = self::lower($charset);
 
         if ($charset == 'utf-8' || $charset == 'utf8') {
-            return strlen(utf8_decode($string));
+            if (Horde_Util::extensionExists('mbstring')) {
+                return strlen(mb_convert_encoding($string, 'ISO-8859-1', 'UTF-8'));
+
+            } else if (function_exists('utf8_decode')) {
+                return strlen(@utf8_decode($string));
+            }
         }
 
         if (Horde_Util::extensionExists('mbstring')) {


### PR DESCRIPTION
Request PR for file String.php 
According to the PHP documentation utf8_encode and utf8_decode functions are deprecated in version 8.2
https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated
https://www.php.net/manual/en/function.utf8-encode.php