### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -116,12 +116,12 @@ class Horde_String
              !Horde_Util::extensionExists('mbstring'))) {
             if (($to == 'utf-8') &&
                 in_array($from, array('iso-8859-1', 'us-ascii', 'utf-8'))) {
-                return utf8_encode($input);
+                return mb_convert_encoding($input, 'UTF-8', 'ISO-8859-1');
             }
 
             if (($from == 'utf-8') &&
                 in_array($to, array('iso-8859-1', 'us-ascii', 'utf-8'))) {
-                return utf8_decode($input);
+                return mb_convert_encoding($input, 'ISO-8859-1', 'UTF-8');
             }
         }
 
@@ -376,12 +376,14 @@ class Horde_String
      *
      * @return integer  The string's length.
      */
+
+
     public static function length($string, $charset = 'UTF-8')
     {
         $charset = self::lower($charset);
 
         if ($charset == 'utf-8' || $charset == 'utf8') {
-            return strlen(utf8_decode($string));
+            return strlen(mb_convert_encoding($string, 'ISO-8859-1', 'UTF-8'));
         }
 
         if (Horde_Util::extensionExists('mbstring')) {

--- a/lib/Horde/Variables.php
+++ b/lib/Horde/Variables.php
@@ -134,7 +134,7 @@ class Horde_Variables implements ArrayAccess, Countable, IteratorAggregate
      *
      * @see __isset()
      */
-    public function offsetExists($field)
+    public function offsetExists($field): bool
     {
         return $this->__isset($field);
     }
@@ -172,7 +172,7 @@ class Horde_Variables implements ArrayAccess, Countable, IteratorAggregate
      *
      * @see __get()
      */
-    public function offsetGet($field)
+    public function offsetGet($field): mixed
     {
         return $this->__get($field);
     }
@@ -237,7 +237,7 @@ class Horde_Variables implements ArrayAccess, Countable, IteratorAggregate
      *
      * @see __set()
      */
-    public function offsetSet($field, $value)
+    public function offsetSet($field, $value):void
     {
         $this->__set($field, $value);
     }
@@ -284,7 +284,7 @@ class Horde_Variables implements ArrayAccess, Countable, IteratorAggregate
      *
      * @see __unset()
      */
-    public function offsetUnset($field)
+    public function offsetUnset($field): void
     {
         $this->__unset($field);
     }
@@ -388,14 +388,14 @@ class Horde_Variables implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_vars);
     }
 
     /* IteratorAggregate method. */
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_vars);
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Util/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Util/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Util Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Util/ArrayTest.php
+++ b/test/Horde/Util/ArrayTest.php
@@ -6,6 +6,7 @@
  * @package    Util
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Util_ArrayTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Util/ArrayTest.php
+++ b/test/Horde/Util/ArrayTest.php
@@ -6,9 +6,9 @@
  * @package    Util
  * @subpackage UnitTests
  */
-class Horde_Util_ArrayTest extends PHPUnit_Framework_TestCase
+class Horde_Util_ArrayTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->array = array(
             array('name' => 'foo', 'desc' => 'foo long desc'),

--- a/test/Horde/Util/DomhtmlTest.php
+++ b/test/Horde/Util/DomhtmlTest.php
@@ -190,7 +190,7 @@ EOT;
     {
         $dom = new Horde_Domhtml('<html><body><div>foo</div></body></html>', 'UTF-8');
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/"text\/html; charset=utf-8"/',
             $dom->returnHtml(array('metacharset' => true))
         );

--- a/test/Horde/Util/DomhtmlTest.php
+++ b/test/Horde/Util/DomhtmlTest.php
@@ -6,7 +6,7 @@
  * @package    Util
  * @subpackage UnitTests
  */
-class Horde_Util_DomhtmlTest extends PHPUnit_Framework_TestCase
+class Horde_Util_DomhtmlTest extends Horde_Test_Case
 {
     public function testBug9567()
     {
@@ -113,9 +113,7 @@ EOT;
 
         foreach ($dom as $node) {
             if ($node instanceof DOMElement) {
-                if ($node->tagName != reset($tags)) {
-                    $this->fail('Wrong tag name.');
-                }
+                $this->assertEquals($node->tagName, reset($tags));
                 array_shift($tags);
             }
         }

--- a/test/Horde/Util/StringTest.php
+++ b/test/Horde/Util/StringTest.php
@@ -6,9 +6,9 @@
  * @package    Util
  * @subpackage UnitTests
  */
-class Horde_Util_StringTest extends PHPUnit_Framework_TestCase
+class Horde_Util_StringTest extends Horde_Test_Case
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         setlocale(LC_ALL, '');
     }
@@ -666,7 +666,7 @@ EOT
         $string = str_repeat('1 A B', 10000);
 
         /* Failing test will cause a PHP segfault here. */
-        Horde_String::validUtf8($string);
+        $this->assertTrue(Horde_String::validUtf8($string));
     }
 
     /**

--- a/test/Horde/Util/StringTest.php
+++ b/test/Horde/Util/StringTest.php
@@ -36,6 +36,7 @@ class Horde_Util_StringTest extends Horde_Test_Case
         if (!setlocale(LC_ALL, 'tr_TR')) {
             $this->markTestSkipped('No Turkish locale installed.');
         }
+        $this->markTestSkipped('Should be fixed by upstream.');
         $one = Horde_String::convertCharset(strtoupper('abCDefGHiI'),
                                             'iso-8859-9', 'utf-8');
         $two = Horde_String::upper('abCDefGHiI');
@@ -67,6 +68,7 @@ class Horde_Util_StringTest extends Horde_Test_Case
         if (!setlocale(LC_ALL, 'tr_TR')) {
             $this->markTestSkipped('No Turkish locale installed.');
         }
+        $this->markTestSkipped('Should be fixed by upstream.');
         $one = Horde_String::convertCharset(strtolower('abCDefGHiI'),
                                             'iso-8859-9', 'utf-8');
         $two = Horde_String::lower('abCDefGHiI');
@@ -116,6 +118,7 @@ class Horde_Util_StringTest extends Horde_Test_Case
         if (!setlocale(LC_ALL, 'tr_TR')) {
             $this->markTestSkipped('No Turkish locale installed.');
         }
+        $this->markTestSkipped('Should be fixed by upstream.');
         $one = Horde_String::convertCharset(ucfirst('integer'),
                                             'iso-8859-9', 'utf-8');
         $two = Horde_String::ucfirst('integer');

--- a/test/Horde/Util/TransliterateTest.php
+++ b/test/Horde/Util/TransliterateTest.php
@@ -6,7 +6,7 @@
  * @package    Util
  * @subpackage UnitTests
  */
-class Horde_Util_TransliterateTest extends PHPUnit_Framework_TestCase
+class Horde_Util_TransliterateTest extends Horde_Test_Case
 {
     /**
      * @dataProvider fallbackDataProvider

--- a/test/Horde/Util/UtilTest.php
+++ b/test/Horde/Util/UtilTest.php
@@ -6,7 +6,7 @@
  * @package    Util
  * @subpackage UnitTests
  */
-class Horde_Util_UtilTest extends PHPUnit_Framework_TestCase
+class Horde_Util_UtilTest extends Horde_Test_Case
 {
     public function testGetPathInfo()
     {

--- a/test/Horde/Util/VariablesTest.php
+++ b/test/Horde/Util/VariablesTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Util_VariablesTest extends PHPUnit_Framework_TestCase
+class Horde_Util_VariablesTest extends Horde_Test_Case
 {
     public function testRemove()
     {

--- a/test/Horde/Util/phpunit.xml
+++ b/test/Horde/Util/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: PHPUnit 8.x adaptations https://salsa.debian.org/horde-team/php-horde-util/-/blob/debian-sid/debian/patches/1001_PHPUnit-8.x.patch
- Debian changes: Silence deprecation warnings with PHP 8.1 https://salsa.debian.org/horde-team/php-horde-util/-/blob/debian-sid/debian/patches/1002_PHP-8.1.patch
- Debian changes: 1010_PHPUnit-8.2.patch https://salsa.debian.org/horde-team/php-horde-util/-/blob/debian-sid/debian/patches/1010_PHPUnit-8.2.patch
