### PR TITLE
Improve array utils

### DIFF
--- a/lib/Horde/Array.php
+++ b/lib/Horde/Array.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The Horde_Array:: class provides various methods for array manipulation.
  *
@@ -28,8 +29,7 @@ class Horde_Array
      *                          1 = descending
      * @param boolean $assoc  Keep key value association?
      */
-    public static function arraySort(array &$array, $key = null, $dir = 0,
-                                     $assoc = true)
+    public static function arraySort(array &$array, $key = null, $dir = 0, $assoc = true)
     {
         /* Return if the array is empty. */
         if (empty($array)) {
@@ -75,6 +75,27 @@ class Horde_Array
         $keys[0] = substr($keys[0], 1);
         $keys[count($keys) - 1] = substr($keys[count($keys) - 1], 0, strlen($keys[count($keys) - 1]) - 1);
         return true;
+    }
+
+    /**
+     * Given an HTML type array field "example[key1][key2][key3]" breaks up
+     * the keys into [ 'example', 'key1', 'key2', 'key3' ] so that they could be
+     * used to reference a regular PHP array.
+     *
+     * @param string $field  The field name to be examined.
+     *
+     * @return array|null    Array of keys, null on error.
+     */
+    public static function getFieldParts($field)
+    {
+        if (preg_match('|^([^\[]*)((\[[^\[\]]*\])*)$|', $field, $matches)) {
+            $keys = [ $matches[1] ];
+            if (strlen($matches[2])) {
+                $keys = array_merge($keys, explode('][', substr($matches[2], 1, -1)));
+            }
+            return $keys;
+        }
+        return null;
     }
 
     /**
@@ -146,8 +167,7 @@ class Horde_Array
      *
      * @return array  The extracted rectangle.
      */
-    public static function getRectangle(array $array, $row, $col, $height,
-                                        $width)
+    public static function getRectangle(array $array, $row, $col, $height, $width)
     {
         $rec = array();
         for ($y = $row; $y < $row + $height; $y++) {

--- a/lib/Horde/Array.php
+++ b/lib/Horde/Array.php
@@ -100,30 +100,25 @@ class Horde_Array
 
     /**
      * Using an array of keys iterate through the array following the
-     * keys to find the final key value. If a value is passed then set
-     * that value.
+     * keys to find the final key value.
      *
-     * @param array &$array  The array to be used.
-     * @param array &$keys   The key path to follow as an array.
-     * @param array $value   If set the target element will have this value set
-     *                       to it.
+     * @param array $array        The array to be used.
+     * @param array|string $keys  The key path to follow as an array.
      *
-     * @return mixed  The final value of the key path.
+     * @return mixed              The final value of the key path.
      */
-    public static function getElement(&$array, array &$keys, $value = null)
+    public static function getElement(array $array, $keys)
     {
-        if (count($keys)) {
-            $key = array_shift($keys);
-            return isset($array[$key])
-                ? self::getElement($array[$key], $keys, $value)
-                : false;
+        $ref = &$array;
+
+        foreach ((array) $keys as $key) {
+            if (!isset($ref[$key])) {
+                return null;
+            }
+            $ref = &$ref[$key];
         }
 
-        if (!is_null($value)) {
-            $array = $value;
-        }
-
-        return $array;
+        return $ref;
     }
 
     /**

--- a/lib/Horde/Array.php
+++ b/lib/Horde/Array.php
@@ -134,17 +134,26 @@ class Horde_Array
      * Using an array of keys iterate through the $array following the
      * nested $keys to find the final key's value. If a $value is passed then set
      * that value. If missing, create array levels along that path.
-     * Existing values in that path will be overwritten even if $value is null.
+     * Existing value in that path will be overwritten.
      *
      * @param array &$array       The array to be used.
      * @param array|string $keys  The key path to follow as an array or string.
      * @param mixed $value        Target element will have this value set to it.
+     * @param string $extraKey    Additional key to add at position 1, if any.
      */
-    public static function setElement(array &$array, $keys, $value = null)
+    public static function setElement(array &$array, $keys, $value, $extraKey = null)
     {
         $ref = &$array;
 
-        foreach ((array) $keys as $key) {
+        if (!is_array($keys)) {
+            $keys = [ $keys ];
+        }
+
+        if (isset($extraKey)) {
+            array_splice($keys, 1, 0, $extraKey);
+        }
+
+        foreach ($keys as $key) {
             if (!isset($ref[$key])) {
                 $ref[$key] = [];
             }

--- a/lib/Horde/Array.php
+++ b/lib/Horde/Array.php
@@ -103,15 +103,24 @@ class Horde_Array
      * keys to find the final key value.
      *
      * @param array $array        The array to be used.
-     * @param array|string $keys  The key path to follow as an array.
+     * @param array|string $keys  The key path to follow as an array or string.
+     * @param string $extraKey    Additional key to add at position 1, if any.
      *
      * @return mixed              The final value of the key path.
      */
-    public static function getElement(array $array, $keys)
+    public static function getElement(array $array, $keys, $extraKey = null)
     {
         $ref = &$array;
 
-        foreach ((array) $keys as $key) {
+        if (!is_array($keys)) {
+            $keys = [ $keys ];
+        }
+
+        if (isset($extraKey)) {
+            array_splice($keys, 1, 0, $extraKey);
+        }
+
+        foreach ($keys as $key) {
             if (!isset($ref[$key])) {
                 return null;
             }

--- a/lib/Horde/Array.php
+++ b/lib/Horde/Array.php
@@ -32,7 +32,7 @@ class Horde_Array
     public static function arraySort(array &$array, $key = null, $dir = 0, $assoc = true)
     {
         /* Return if the array is empty. */
-        if (empty($array)) {
+        if (!$array) {
             return;
         }
 
@@ -48,9 +48,9 @@ class Horde_Array
         $helper->key = $key;
         $function = $dir ? 'reverseCompare' : 'compare';
         if ($assoc) {
-            uasort($array, array($helper, $function));
+            uasort($array, [ $helper, $function ]);
         } else {
-            usort($array, array($helper, $function));
+            usort($array, [ $helper, $function ]);
         }
     }
 
@@ -62,7 +62,7 @@ class Horde_Array
      * @param string &$base  Will be set to the base element.
      * @param array &$keys   Will be set to the list of keys.
      *
-     * @return boolean  True on sucess, false on error.
+     * @return boolean  True on success, false on error.
      */
     public static function getArrayParts($field, &$base, &$keys)
     {
@@ -127,28 +127,22 @@ class Horde_Array
      * that value. If missing, create array levels along that path.
      * Existing values in that path will be overwritten even if $value is null.
      *
-     * @param array &$array  The array to be used.
-     * @param array &$keys   The key path to follow as an array.
-     * @param array $value   Target element will have this value set
-     *                       to it.
-     *
-     * @return mixed  The final value of the key path.
+     * @param array &$array       The array to be used.
+     * @param array|string $keys  The key path to follow as an array or string.
+     * @param mixed $value        Target element will have this value set to it.
      */
-    public static function setElement(&$array, array &$keys, $value = null)
+    public static function setElement(array &$array, $keys, $value = null)
     {
-        if (count($keys)) {
-            $key = array_shift($keys);
-            if (!isset($array[$key])) {
-                $array[$key] = array();
+        $ref = &$array;
+
+        foreach ((array) $keys as $key) {
+            if (!isset($ref[$key])) {
+                $ref[$key] = [];
             }
-            return isset($array[$key])
-                ? self::setElement($array[$key], $keys, $value)
-                : false;
+            $ref = &$ref[$key];
         }
 
-        $array = $value;
-
-        return $array;
+        $ref = $value;
     }
 
     /**
@@ -164,7 +158,7 @@ class Horde_Array
      */
     public static function getRectangle(array $array, $row, $col, $height, $width)
     {
-        $rec = array();
+        $rec = [];
         for ($y = $row; $y < $row + $height; $y++) {
             $rec[] = array_slice($array[$y], $col, $width);
         }
@@ -175,9 +169,9 @@ class Horde_Array
      * Given an array, returns an associative array with each element key
      * derived from its value.
      * For example:
-     *   array(0 => 'foo', 1 => 'bar')
+     *   [ 0 => 'foo', 1 => 'bar' ]
      * would become:
-     *   array('foo' => 'foo', 'bar' => 'bar')
+     *   [ 'foo' => 'foo', 'bar' => 'bar' ]
      *
      * @param array $array  An array of values.
      *
@@ -187,6 +181,6 @@ class Horde_Array
     {
         return $array
             ? array_combine($array, $array)
-            : array();
+            : [];
     }
 }

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -38,8 +38,7 @@ class ArrayUtils
         $key = null,
         $dir = 0,
         $assoc = true
-    )
-    {
+    ) {
         /* Return if the array is empty. */
         if (empty($array)) {
             return;
@@ -84,6 +83,27 @@ class ArrayUtils
         $keys[0] = substr($keys[0], 1);
         $keys[count($keys) - 1] = substr($keys[count($keys) - 1], 0, strlen($keys[count($keys) - 1]) - 1);
         return true;
+    }
+
+    /**
+     * Given an HTML type array field "example[key1][key2][key3]" breaks up
+     * the keys into [ 'example', 'key1', 'key2', 'key3' ] so that they could be
+     * used to reference a regular PHP array.
+     *
+     * @param string $field  The field name to be examined.
+     *
+     * @return array|null    Array of keys, null on error.
+     */
+    public static function getFieldParts($field)
+    {
+        if (preg_match('|^([^\[]*)((\[[^\[\]]*\])*)$|', $field, $matches)) {
+            $keys = [ $matches[1] ];
+            if (strlen($matches[2])) {
+                $keys = array_merge($keys, explode('][', substr($matches[2], 1, -1)));
+            }
+            return $keys;
+        }
+        return null;
     }
 
     /**
@@ -160,8 +180,7 @@ class ArrayUtils
         $col,
         $height,
         $width
-    )
-    {
+    ) {
         $rec = [];
         for ($y = $row; $y < $row + $height; $y++) {
             $rec[] = array_slice($array[$y], $col, $width);

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -142,17 +142,26 @@ class ArrayUtils
      * Using an array of keys iterate through the $array following the
      * nested $keys to find the final key's value. If a $value is passed then set
      * that value. If missing, create array levels along that path.
-     * Existing values in that path will be overwritten even if $value is null.
+     * Existing value in that path will be overwritten.
      *
      * @param array &$array       The array to be used.
      * @param array|string $keys  The key path to follow as an array or string.
      * @param mixed $value        Target element will have this value set to it.
+     * @param string $extraKey    Additional key to add at position 1, if any.
      */
-    public static function setElement(array &$array, $keys, $value = null)
+    public static function setElement(array &$array, $keys, $value, $extraKey = null)
     {
         $ref = &$array;
 
-        foreach ((array) $keys as $key) {
+        if (!is_array($keys)) {
+            $keys = [ $keys ];
+        }
+
+        if (isset($extraKey)) {
+            array_splice($keys, 1, 0, $extraKey);
+        }
+
+        foreach ($keys as $key) {
             if (!isset($ref[$key])) {
                 $ref[$key] = [];
             }

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -111,15 +111,24 @@ class ArrayUtils
      * keys to find the final key value.
      *
      * @param array $array        The array to be used.
-     * @param array|string $keys  The key path to follow as an array.
+     * @param array|string $keys  The key path to follow as an array or string.
+     * @param string $extraKey    Additional key to add at position 1, if any.
      *
      * @return mixed              The final value of the key path.
      */
-    public static function getElement(array $array, $keys)
+    public static function getElement(array $array, $keys, $extraKey = null)
     {
         $ref = &$array;
 
-        foreach ((array) $keys as $key) {
+        if (!is_array($keys)) {
+            $keys = [ $keys ];
+        }
+
+        if (isset($extraKey)) {
+            array_splice($keys, 1, 0, $extraKey);
+        }
+
+        foreach ($keys as $key) {
             if (!isset($ref[$key])) {
                 return null;
             }

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -108,31 +108,27 @@ class ArrayUtils
 
     /**
      * Using an array of keys iterate through the array following the
-     * keys to find the final key value. If a value is passed then set
-     * that value.
+     * keys to find the final key value.
      *
-     * @param array &$array  The array to be used.
-     * @param array &$keys   The key path to follow as an array.
-     * @param array $value   If set the target element will have this value set
-     *                       to it.
+     * @param array $array        The array to be used.
+     * @param array|string $keys  The key path to follow as an array.
      *
-     * @return mixed  The final value of the key path.
+     * @return mixed              The final value of the key path.
      */
-    public static function getElement(&$array, array &$keys, $value = null)
+    public static function getElement(array $array, $keys)
     {
-        if (count($keys)) {
-            $key = array_shift($keys);
-            return isset($array[$key])
-                ? self::getElement($array[$key], $keys, $value)
-                : false;
+        $ref = &$array;
+
+        foreach ((array) $keys as $key) {
+            if (!isset($ref[$key])) {
+                return null;
+            }
+            $ref = &$ref[$key];
         }
 
-        if (!is_null($value)) {
-            $array = $value;
-        }
-
-        return $array;
+        return $ref;
     }
+
     /**
      * Using an array of keys iterate through the $array following the
      * nested $keys to find the final key's value. If a $value is passed then set

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -135,28 +135,22 @@ class ArrayUtils
      * that value. If missing, create array levels along that path.
      * Existing values in that path will be overwritten even if $value is null.
      *
-     * @param array &$array  The array to be used.
-     * @param array &$keys   The key path to follow as an array.
-     * @param array $value   Target element will have this value set
-     *                       to it.
-     *
-     * @return mixed  The final value of the key path.
+     * @param array &$array       The array to be used.
+     * @param array|string $keys  The key path to follow as an array or string.
+     * @param mixed $value        Target element will have this value set to it.
      */
-    public static function setElement(&$array, array &$keys, $value = null)
+    public static function setElement(array &$array, $keys, $value = null)
     {
-        if (count($keys)) {
-            $key = array_shift($keys);
-            if (!isset($array[$key])) {
-                $array[$key] = array();
+        $ref = &$array;
+
+        foreach ((array) $keys as $key) {
+            if (!isset($ref[$key])) {
+                $ref[$key] = [];
             }
-            return isset($array[$key])
-                ? self::setElement($array[$key], $keys, $value)
-                : false;
+            $ref = &$ref[$key];
         }
 
-        $array = $value;
-
-        return $array;
+        $ref = $value;
     }
 
     /**


### PR DESCRIPTION
This closes #15.

1) Add `getFieldParts()` to split field into path.
This function is an improved alternative of `getArrayParts()`. 
Instead of returning `$base` and `$keys` (passed by reference), it returns a simple array with base (field name) and keys (if any).

It supports simple fields (without keys), which allows to simplify many existing places. For example:
```php
if (Horde_Array::getArrayParts($varname, $base, $keys)) {
    array_unshift($keys, $base);
    $place = &$this->_vars;
    $i = count($keys);

    while ($i--) {
        $key = array_shift($keys);
        if (!isset($place[$key])) {
            $place[$key] = array();
        }
        $place = &$place[$key];
    }

    $place = $value;
} else {
    $this->_vars[$varname] = $value;
}
```
becomes
```php
$keys = Horde_Array::getFieldParts($varname);
// note, "if" check is not strictly needed ($keys would be null only if $varname is malformed)
if ($keys) {
    Horde_Array::setElement($this->_vars, $keys, $value);
}
```
2) Reimplement `getElement()`
 * Make it non-recursive
 * Drop `$value` parameter (`setElement` should be used instead)
 * Do not modify `$array` or `$keys`
 * Return `null` on error
 * Add support for extra key

This allows to to further simplify many existing places. For example:
```php
/* Get the other parts of the upload. */
Horde_Array::getArrayParts($varname . '[new]', $base, $keys);

/* Get the temporary file name. */
$keys_path = array_merge([$base, 'tmp_name'], $keys);
$this->_img['img']['file'] = Horde_Array::getElement($_FILES, $keys_path);

/* Get the actual file name. */
$keys_path = array_merge([$base, 'name'], $keys);
$this->_img['img']['name'] = Horde_Array::getElement($_FILES, $keys_path);

/* Get the file size. */
$keys_path = array_merge([$base, 'size'], $keys);
$this->_img['img']['size'] = Horde_Array::getElement($_FILES, $keys_path);
```
becomes
```php
/* Get the other parts of the upload. */
$keys = Horde_Array::getFieldParts($varname . '[new]');

/* Get the temporary file name. */
$this->_img['img']['file'] = Horde_Array::getElement($_FILES, $keys, 'tmp_name');

/* Get the actual file name. */
$this->_img['img']['name'] = Horde_Array::getElement($_FILES, $keys, 'name');

/* Get the file size. */
$this->_img['img']['size'] = Horde_Array::getElement($_FILES, $keys, 'size');
```

3)  Reimplement setElement()
  * Make it non-recursive
  * Do not modify `$keys`
  * Do not return value

**Once the PR is merged, I will provide multiple additional PRs to simplify the code based on the above examples.**
