### PR TITLE
Fixed deprecation warnings in test files for php 8.3

### DIFF
--- a/test/ArrayUtilsTest.php
+++ b/test/ArrayUtilsTest.php
@@ -9,9 +9,11 @@
 
 namespace Horde\Util\Test;
 
+use AllowDynamicProperties;
 use PHPUnit\Framework\TestCase;
 use Horde\Util\ArrayUtils;
 
+#[AllowDynamicProperties]
 class ArrayUtilsTest extends TestCase
 {
     public function setUp(): void

--- a/test/Unnamespaced/ArrayTest.php
+++ b/test/Unnamespaced/ArrayTest.php
@@ -9,9 +9,11 @@
 
 namespace Horde\Util\Test\Unnamespaced;
 
+use AllowDynamicProperties;
 use PHPUnit\Framework\TestCase;
 use Horde_Array;
 
+#[AllowDynamicProperties]
 class ArrayTest extends TestCase
 {
     public function setUp(): void


### PR DESCRIPTION
Referenced: https://stackoverflow.com/questions/74878889/php-warning-deprecated-creation-of-dynamic-property-is-deprecated