### PR TITLE
fix(string): prevent out-of-bounds access in validUtf8()

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -950,6 +950,9 @@ class Horde_String
                 }
 
                 do {
+                    if ($i + 1 >= $len) {
+                        return false;
+                    }
                     $c = ord($text[++$i]);
                     if (($c < 128) || ($c > 191)) {
                         return false;

--- a/src/HordeString.php
+++ b/src/HordeString.php
@@ -915,6 +915,9 @@ class HordeString
                 }
 
                 do {
+                    if ($i + 1 >= $len) {
+                        return false;
+                    }
                     $c = ord($text[++$i]);
                     if (($c < 128) || ($c > 191)) {
                         return false;


### PR DESCRIPTION
Port PR #4 from pravussum to both lib/ and src/ versions.

Fixes "Uninitialized string offset" error when validUtf8() processes truncated UTF-8 multi-byte sequences at the end of a string.

Closes #4 