### PR TITLE
fix setlocale to provide proper type

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -261,7 +261,7 @@ class Horde_String
         $string = $string ?? '';
 
         if (!isset(self::$_lowers[$string])) {
-            $language = setlocale(LC_CTYPE, 0);
+            $language = setlocale(LC_CTYPE, '0');
             setlocale(LC_CTYPE, 'C');
             self::$_lowers[$string] = strtolower($string);
             setlocale(LC_CTYPE, $language);
@@ -297,7 +297,7 @@ class Horde_String
         }
 
         if (!isset(self::$_uppers[$string])) {
-            $language = setlocale(LC_CTYPE, 0);
+            $language = setlocale(LC_CTYPE, '0');
             setlocale(LC_CTYPE, 'C');
             self::$_uppers[$string] = strtoupper($string);
             setlocale(LC_CTYPE, $language);

--- a/src/HordeString.php
+++ b/src/HordeString.php
@@ -269,7 +269,7 @@ class HordeString
         }
 
         if (!isset(self::$_lowers[$string])) {
-            $language = setlocale(LC_CTYPE, 0);
+            $language = setlocale(LC_CTYPE, '0');
             setlocale(LC_CTYPE, 'C');
             if ($string === null) {
                 self::$_lowers[$string] = '';
@@ -322,7 +322,7 @@ class HordeString
         }
 
         if (!isset(self::$_uppers[$string])) {
-            $language = setlocale(LC_CTYPE, 0);
+            $language = setlocale(LC_CTYPE, '0');
             setlocale(LC_CTYPE, 'C');
             self::$_uppers[$string] = strtoupper($string);
             setlocale(LC_CTYPE, $language);


### PR DESCRIPTION
This will fix setlocale to provide the proper type.

Changed: $locale = setlocale(LC_ALL, 0);
to: $locale = setlocale(LC_ALL, '0');

will change it to null if preferred.

Going to do this for horde/date, horde/util, horde/autoloader as well.

@ralflang , @TDannhauer