### PR TITLE
Fix/ambigous charset

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -183,7 +183,10 @@ class Horde_String
         if (class_exists('UConverter')) {
             $attemptedMethods[] = 'UConverter';
             try {
-                $conv = new UConverter($to, $from);
+                $conv = new UConverter(
+                    CharacterSets::toUConverter($to),
+                    CharacterSets::toUConverter($from)
+                );
                 $out = $conv->convert($input);
                 if ($out !== false && $out !== '') {
                     return $out;

--- a/src/CharacterSets.php
+++ b/src/CharacterSets.php
@@ -36,6 +36,24 @@ class CharacterSets
     ];
 
     /**
+     * Map charset aliases to unambiguous ICU canonical names for UConverter.
+     *
+     * PHP's UConverter emits "Ambiguous encoding specified" warnings for names
+     * that map to multiple ICU converters (e.g. windows-1258 → ibm-5354 or
+     * cp1258). Use the canonical name PHP would pick anyway.
+     *
+     * @see https://www.php.net/manual/en/class.uconverter.php
+     */
+    private static array $uconverterMap = [
+        'big5-hkscs' => 'ibm-1375_P100-2008',
+        'shift_jis' => 'ibm-943_P15A-2003',
+        'tis-620' => 'windows-874-2000',
+        'windows-1258' => 'cp1258',
+        'windows-936' => 'windows-936-2000',
+        'windows-950' => 'windows-950-2000',
+    ];
+
+    /**
      * Normalize a character set identifier to a canonical name.
      *
      * This should be called before passing charset names to any conversion
@@ -64,5 +82,20 @@ class CharacterSets
     {
         // TODO: Check against mb_list_encoding
         return self::normalize($identifier);
+    }
+
+    /**
+     * Convert charset identifier to an unambiguous UConverter/ICU name.
+     *
+     * @param string $identifier  The charset identifier.
+     *
+     * @return string  The UConverter-compatible charset name.
+     */
+    public static function toUConverter(string $identifier): string
+    {
+        $identifier = self::normalize($identifier);
+        $lower = strtolower($identifier);
+
+        return self::$uconverterMap[$lower] ?? $identifier;
     }
 }

--- a/src/HordeString.php
+++ b/src/HordeString.php
@@ -199,7 +199,10 @@ class HordeString
         if (class_exists('UConverter')) {
             $attemptedMethods[] = 'UConverter';
             try {
-                $conv = new UConverter($to, $from);
+                $conv = new UConverter(
+                    CharacterSets::toUConverter($to),
+                    CharacterSets::toUConverter($from)
+                );
                 $out = $conv->convert($input);
                 if ($out !== false && $out !== '') {
                     return $out;

--- a/test/CharacterSetsTest.php
+++ b/test/CharacterSetsTest.php
@@ -78,4 +78,16 @@ class CharacterSetsTest extends TestCase
         // Non-normalized charsets should pass through
         $this->assertEquals('iso-8859-1', CharacterSets::toMbstring('iso-8859-1'));
     }
+
+    public function testToUConverterWindows1258(): void
+    {
+        $this->assertEquals('cp1258', CharacterSets::toUConverter('windows-1258'));
+        $this->assertEquals('cp1258', CharacterSets::toUConverter('Windows-1258'));
+    }
+
+    public function testToUConverterPreservesUnambiguousCharsets(): void
+    {
+        $this->assertEquals('iso-8859-1', CharacterSets::toUConverter('iso-8859-1'));
+        $this->assertEquals('utf-8', CharacterSets::toUConverter('utf8mb4'));
+    }
 }


### PR DESCRIPTION
# Silence UConverter “ambiguous encoding” warnings for common charsets

## Summary

- Add `CharacterSets::toUConverter()` to map charset names that ICU treats as ambiguous to stable canonical names before constructing `UConverter`.
- Use `toUConverter()` for both source and destination encodings in `HordeString::_convertCharset()` (and the legacy `Horde_String` wrapper).
- Add unit tests for `windows-1258` and pass-through behavior for unambiguous charsets.

## Problem

When iconv and mbstring cannot convert a string, `HordeString::_convertCharset()` falls back to PHP’s intl `UConverter`. Several widely used charset labels are **ambiguous** in ICU: PHP accepts them but emits a warning and picks one canonical mapping, for example:

```
UConverter::__construct(): Ambiguous encoding specified, using ibm-5354_P100-1998
```

This is commonly triggered by **`windows-1258`** (Vietnamese), which Horde lowercases from MIME labels like `Windows-1258`. The warning appears on line 202 of `HordeString.php` and can flood Horde logs during mail/ActiveSync processing even though conversion succeeds.

Other affected aliases include `big5-hkscs`, `shift_jis`, `tis-620`, `windows-936`, and `windows-950`.

## Solution

1. Extend `CharacterSets` with a small `$uconverterMap` (after `normalize()`) that maps ambiguous aliases to the same ICU canonical names PHP would select anyway (e.g. `windows-1258` → `cp1258`, which resolves to `ibm-5354_P100-1998` without a warning).
2. Call `CharacterSets::toUConverter($from)` and `CharacterSets::toUConverter($to)` immediately before `new UConverter($to, $from)`.
3. Leave iconv and mbstring paths unchanged; they already accept names like `windows-1258`.

Behavior is unchanged; only log noise is removed.

## Files changed

| File | Change |
|------|--------|
| `src/CharacterSets.php` | `$uconverterMap`, `toUConverter()` |
| `src/HordeString.php` | Use `toUConverter()` for UConverter fallback |
| `lib/Horde/String.php` | Same for legacy class |
| `test/CharacterSetsTest.php` | Tests for `toUConverter()` |

## Test plan

- [ ] With intl enabled, run: `new UConverter('utf-8', 'windows-1258')` before/after — confirm no `Ambiguous encoding` warning after the patch.
- [ ] `HordeString::convertCharset('<html>', 'UTF-8', 'Windows-1258')` returns unchanged ASCII (existing `testBug9528`).
- [ ] `vendor/bin/phpunit test/CharacterSetsTest.php` passes.
- [ ] Process mail or ActiveSync traffic that previously logged `ibm-5354_P100-1998` warnings; confirm logs are clean and message bodies still display correctly for Vietnamese (`windows-1258`) content.
